### PR TITLE
Enhancement - Add low memory warning listener to Android

### DIFF
--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -75,6 +75,11 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
   }
 
   @Override
+  public void onLowMemory() {
+    // no-op
+  }
+
+  @Override
   public void initialize() {
     getReactApplicationContext().addLifecycleEventListener(this);
     getReactApplicationContext().registerComponentCallbacks(this);

--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -4,7 +4,7 @@ import android.os.Environment;
 import android.os.StatFs;
 import android.os.Build;
 import android.os.Debug;
-import android.content.ComponentCallbacks;
+import android.content.ComponentCallbacks2;
 import android.content.res.Configuration;
 import android.app.ActivityManager;
 import android.content.Context;

--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -9,6 +9,7 @@ import android.content.res.Configuration;
 import android.app.ActivityManager;
 import android.content.Context;
 
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -22,7 +23,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 
-public class RNVitalsModule extends ReactContextBaseJavaModule implements ComponentCallbacks {
+public class RNVitalsModule extends ReactContextBaseJavaModule implements ComponentCallbacks2, LifecycleEventListener {
 
   public static final String MODULE_NAME = "RNVitals";
   public static final String LOW_MEMORY = "LOW_MEMORY";
@@ -66,11 +67,32 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
   }
 
   @Override
-  public void onLowMemory() {
+  public void onTrimMemory(level) {
     ReactApplicationContext context = getReactApplicationContext();
     if (context.hasActiveCatalystInstance()) {
       context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(LOW_MEMORY, getMemoryInfo());
     }
+  }
+
+  @Override
+  public void initialize() {
+    getReactApplicationContext().addLifecycleEventListener(this);
+    getReactApplicationContext().registerComponentCallbacks(this);
+  }
+
+  @Override
+  public void onHostResume() {
+    getReactApplicationContext().registerComponentCallbacks(this);
+  }
+
+  @Override
+  public void onHostPause() {
+    getReactApplicationContext().unregisterComponentCallbacks(this);
+  }
+
+  @Override
+  public void onHostDestroy() {
+    getReactApplicationContext().unregisterComponentCallbacks(this);
   }
 
   @Override

--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -98,6 +98,7 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
   @Override
   public void onHostDestroy() {
     getReactApplicationContext().unregisterComponentCallbacks(this);
+    getReactApplicationContext().removeLifecycleEventListener(this);
   }
 
   @Override

--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -67,7 +67,7 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
   }
 
   @Override
-  public void onTrimMemory(level) {
+  public void onTrimMemory(int level) {
     ReactApplicationContext context = getReactApplicationContext();
     if (context.hasActiveCatalystInstance()) {
       context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(LOW_MEMORY, getMemoryInfo());


### PR DESCRIPTION
This PR aims to bring Android support up to par with iOS. From now on, low memory warnings will be sent over to the JS side via the low memory warning listener.

## Implementation Details

`ComponentCallbacks2` is an updated interface used to listen to low memory notifications sent by the OS. `ComponentCallbacks` was first introduced in `API 1` and comes with the `onLowMemory()` method that would usually trigger when the device is running low on memory and requires trimming.

Fast forwarding to `API 14`, Android introduced ComponentCallbacks2 with the `onTrimMemory(int level)` method that the OS calls when it has determined that it is a good time for a process to trim unneeded memory from its process, alongside with the level of severity, that hints to the amount of trimming the application may like to perform. Even though `onTrimMemory()` should be used starting from `API 14`, we're still required to implement `onLowMemory()` since `ComponentCallbacks2` is an interface.

Also, `LifecycleEventListener` is used to observe the app's lifecycle to register & deregister `ComponentCallbacks2`.

- [x] Testing - `adb shell am send-trim-memory com.robinpowered.rooms RUNNING_CRITICAL` to trigger low memory warning