### PR TITLE
Include memory level in low memory warning callbacks for Android 

### DIFF
--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -70,7 +70,9 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
   public void onTrimMemory(int level) {
     ReactApplicationContext context = getReactApplicationContext();
     if (context.hasActiveCatalystInstance()) {
-      context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(LOW_MEMORY, getMemoryInfo());
+      WritableMap memoryInfo = getMemoryInfo();
+      memoryInfo.putInt("memoryLevel", level);
+      context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(LOW_MEMORY, memoryInfo);
     }
   }
 

--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -27,7 +27,7 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
 
   public static final String MODULE_NAME = "RNVitals";
   public static final String LOW_MEMORY = "LOW_MEMORY";
-  public static final String MEMORY_LEVEL = "MEMORY_LEVEL";
+  public static final String MEMORY_LEVEL_KEY = "MemoryLevel";
 
   public static final int MEMORY_MODERATE = TRIM_MEMORY_RUNNING_MODERATE;
   public static final int MEMORY_LOW = TRIM_MEMORY_RUNNING_LOW;
@@ -50,13 +50,13 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
   @Override
   public @Nullable Map<String, Object> getConstants() {
     HashMap<String, Object> memoryLevelConstants = new HashMap<String, Object>();
-    memoryLevelConstants.put("MEMORY_CRITICAL", MEMORY_CRITICAL);
-    memoryLevelConstants.put("MEMORY_LOW", MEMORY_LOW);
-    memoryLevelConstants.put("MEMORY_MODERATE", MEMORY_MODERATE);
+    memoryLevelConstants.put("CRITICAL", MEMORY_CRITICAL);
+    memoryLevelConstants.put("LOW", MEMORY_LOW);
+    memoryLevelConstants.put("MODERATE", MEMORY_MODERATE);
 
     HashMap<String, Object> constants = new HashMap<String, Object>();
     constants.put(LOW_MEMORY, LOW_MEMORY);
-    constants.put(MEMORY_LEVEL, memoryLevelConstants);
+    constants.put(MEMORY_LEVEL_KEY, memoryLevelConstants);
 
     return constants;
   }

--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -27,6 +27,7 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
 
   public static final String MODULE_NAME = "RNVitals";
   public static final String LOW_MEMORY = "LOW_MEMORY";
+  public static final String MEMORY_LEVEL = "MEMORY_LEVEL";
 
   public static final int MEMORY_MODERATE = TRIM_MEMORY_RUNNING_MODERATE;
   public static final int MEMORY_LOW = TRIM_MEMORY_RUNNING_LOW;
@@ -48,11 +49,15 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
 
   @Override
   public @Nullable Map<String, Object> getConstants() {
+    HashMap<String, Object> memoryLevelConstants = new HashMap<String, Object>();
+    memoryLevelConstants.put("MEMORY_CRITICAL", MEMORY_CRITICAL);
+    memoryLevelConstants.put("MEMORY_LOW", MEMORY_LOW);
+    memoryLevelConstants.put("MEMORY_MODERATE", MEMORY_MODERATE);
+
     HashMap<String, Object> constants = new HashMap<String, Object>();
-    constants.put("LOW_MEMORY", LOW_MEMORY);
-    constants.put("MEMORY_CRITICAL", MEMORY_CRITICAL);
-    constants.put("MEMORY_LOW", MEMORY_LOW);
-    constants.put("MEMORY_CRITICAL", MEMORY_CRITICAL);
+    constants.put(LOW_MEMORY, LOW_MEMORY);
+    constants.put(MEMORY_LEVEL, memoryLevelConstants);
+
     return constants;
   }
 

--- a/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
+++ b/android/src/main/java/com/robinpowered/react/vitals/RNVitalsModule.java
@@ -28,6 +28,11 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
   public static final String MODULE_NAME = "RNVitals";
   public static final String LOW_MEMORY = "LOW_MEMORY";
 
+  public static final int MEMORY_MODERATE = TRIM_MEMORY_RUNNING_MODERATE;
+  public static final int MEMORY_LOW = TRIM_MEMORY_RUNNING_LOW;
+  public static final int MEMORY_CRITICAL = TRIM_MEMORY_RUNNING_CRITICAL;
+
+
   public RNVitalsModule(ReactApplicationContext reactContext) {
     super(reactContext);
   }
@@ -45,6 +50,9 @@ public class RNVitalsModule extends ReactContextBaseJavaModule implements Compon
   public @Nullable Map<String, Object> getConstants() {
     HashMap<String, Object> constants = new HashMap<String, Object>();
     constants.put("LOW_MEMORY", LOW_MEMORY);
+    constants.put("MEMORY_CRITICAL", MEMORY_CRITICAL);
+    constants.put("MEMORY_LOW", MEMORY_LOW);
+    constants.put("MEMORY_CRITICAL", MEMORY_CRITICAL);
     return constants;
   }
 

--- a/entry.android.js
+++ b/entry.android.js
@@ -7,8 +7,8 @@ export default {
   ...Vitals,
   // Android overrides
   addLowMemoryListener(callback) {
-    var wrappedCallback = function (memoryInfo) {
-      if (memoryInfo.memoryLevel === Vitals.MEMORY_CRITICAL) {
+    const wrappedCallback = memoryInfo => {
+      if (memoryInfo.memoryLevel === Vitals.MEMORY_LEVEL.MEMORY_CRITICAL) {
         callback(memoryInfo);
       }
     };

--- a/entry.android.js
+++ b/entry.android.js
@@ -1,0 +1,21 @@
+'use strict';
+
+import Vitals from './vitals';
+import {DeviceEventEmitter} from 'react-native';
+
+export default {
+  ...Vitals,
+  // Android overrides
+  addLowMemoryListener(callback) {
+    var wrappedCallback = function (memoryInfo) {
+      if (memoryInfo.memoryLevel === Vitals.MEMORY_CRITICAL) {
+        callback(memoryInfo);
+      }
+    };
+
+    return DeviceEventEmitter.addListener(
+      Vitals.LOW_MEMORY,
+      wrappedCallback
+    );
+  }
+};

--- a/entry.android.js
+++ b/entry.android.js
@@ -8,7 +8,7 @@ export default {
   // Android overrides
   addLowMemoryListener(callback) {
     const wrappedCallback = memoryInfo => {
-      if (memoryInfo.memoryLevel === Vitals.MEMORY_LEVEL.MEMORY_CRITICAL) {
+      if (memoryInfo.memoryLevel === Vitals.MemoryLevel.CRITICAL) {
         callback(memoryInfo);
       }
     };

--- a/entry.ios.js
+++ b/entry.ios.js
@@ -1,0 +1,3 @@
+'use strict';
+
+export {default} from './vitals';

--- a/index.js
+++ b/index.js
@@ -1,18 +1,3 @@
 'use strict';
 
-import {
-  DeviceEventEmitter,
-  NativeModules
-} from 'react-native';
-
-const {RNVitals} = NativeModules;
-
-export default {
-  ...RNVitals,
-  addLowMemoryListener (callback) {
-    return DeviceEventEmitter.addListener(
-      RNVitals.LOW_MEMORY,
-      callback
-    );
-  }
-};
+export {default} from './entry';

--- a/vitals.js
+++ b/vitals.js
@@ -1,0 +1,18 @@
+'use strict';
+
+import {
+  DeviceEventEmitter,
+  NativeModules
+} from 'react-native';
+
+const {RNVitals} = NativeModules;
+
+export default {
+  ...RNVitals,
+  addLowMemoryListener (callback) {
+    return DeviceEventEmitter.addListener(
+      RNVitals.LOW_MEMORY,
+      callback
+    );
+  }
+};


### PR DESCRIPTION
While doing testing for Android, I realized that the `onTrimMemory(int level)` method gets called pretty often. That isn't too surprising since there are 3 different levels of memory usage that a device can be at when the method is being called by the OS, and they are `TRIM_MEMORY_RUNNING_MODERATE `, `TRIM_MEMORY_RUNNING_LOW`, and `TRIM_MEMORY_RUNNING_CRITICAL`. 

Obviously on the client side we wouldn't want to report/restart the device when the memory level is at _moderate_ or _running low_, since there's still an acceptable amount of memory for the device to use and thus this PR will include the memory level in the JS callback so that we can perform the callback conditionally for Android depending on the memory level. 😄 