### PR TITLE
Fix iOS Yellow box warning "requires main queue setup" since it overrides constantsToExport but doesn't implement requiresMainQueueSetup

### DIFF
--- a/ios/RNVitals.m
+++ b/ios/RNVitals.m
@@ -37,6 +37,11 @@ static NSString * const LOW_MEMORY = @"LOW_MEMORY";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 + (NSDictionary *)getMemoryInfo
 {
     struct mach_task_basic_info info;


### PR DESCRIPTION
This PR addresses the following warning:

![RNVitalsWarning](https://user-images.githubusercontent.com/518116/55662004-78ed9f00-57d5-11e9-88cd-b63793702c7f.png)
